### PR TITLE
gemcook/gantt-reactに日付選択機能を追加する。

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@gemcook/gantt": "0.1.4",
+    "@gemcook/gantt": "0.1.5",
     "@gemcook/utils": "^5.1.7",
     "@types/jest": "^24.0.15",
     "@types/node": "12.0.10",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@gemcook/gantt": "^0.1.2",
+    "@gemcook/gantt": "0.1.4",
     "@gemcook/utils": "^5.1.7",
     "@types/jest": "^24.0.15",
     "@types/node": "12.0.10",

--- a/src/GanttSample.tsx
+++ b/src/GanttSample.tsx
@@ -64,14 +64,13 @@ const GanttDemo: React.FC = () => {
     barHeight: 30,
     viewMode: 'Day',
     language: 'ja',
-    selectDay: '2019-06-03',
     startBeforeDay: 30,
     endLaterDay: 60,
   };
 
   return (
     <div>
-      <Gantt tasks={tasks} options={options} />
+      <Gantt tasks={tasks} options={options} selectDay="2019-06-03" />
       <button onClick={() => setTasks(dummyTasks)}>ガント表示ボタン</button>
       <button onClick={() => setTasks([])}>ガントリセットボタン</button>
     </div>

--- a/src/GanttSample.tsx
+++ b/src/GanttSample.tsx
@@ -64,12 +64,16 @@ const GanttDemo: React.FC = () => {
     barHeight: 30,
     viewMode: 'Day',
     language: 'ja',
+    selectDay: '2019-06-03',
+    startBeforeDay: 30,
+    endLaterDay: 60,
   };
 
   return (
     <div>
       <Gantt tasks={tasks} options={options} />
       <button onClick={() => setTasks(dummyTasks)}>ガント表示ボタン</button>
+      <button onClick={() => setTasks([])}>ガントリセットボタン</button>
     </div>
   );
 };

--- a/src/GanttSample.tsx
+++ b/src/GanttSample.tsx
@@ -72,7 +72,6 @@ const GanttDemo: React.FC = () => {
     <div>
       <Gantt tasks={tasks} options={options} selectDay="2019-06-03" />
       <button onClick={() => setTasks(dummyTasks)}>ガント表示ボタン</button>
-      <button onClick={() => setTasks([])}>ガントリセットボタン</button>
     </div>
   );
 };

--- a/src/components/Gantt/index.tsx
+++ b/src/components/Gantt/index.tsx
@@ -13,7 +13,7 @@ const ReactGantt: React.FC<GanttProps> = props => {
   useEffect(() => {
     // キャメルケースで受け取った値をスネークケースにする。
     const options = collection.toSnakeKeys(props.options);
-    const tasks = props.tasks.map(rowTasks => collection.toSnakeKeys(rowTasks));
+    const tasks = collection.toSnakeKeys(props.tasks);
 
     // もしガントが表示済みなら更新する・存在しなければ新しく作成する
     if (gantt) {

--- a/src/components/Gantt/index.tsx
+++ b/src/components/Gantt/index.tsx
@@ -11,11 +11,6 @@ const ReactGantt: React.FC<GanttProps> = props => {
   const [gantt, setGantt] = useState();
 
   useEffect(() => {
-    // tasksが空配列なら処理を中断する
-    if (props.tasks.length === 0) {
-      return;
-    }
-
     // キャメルケースで受け取った値をスネークケースにする。
     const options = collection.toSnakeKeys(props.options);
     const tasks = props.tasks.map(rowTasks => collection.toSnakeKeys(rowTasks));

--- a/src/components/Gantt/index.tsx
+++ b/src/components/Gantt/index.tsx
@@ -22,14 +22,17 @@ const ReactGantt: React.FC<GanttProps> = props => {
 
     // もしガントが表示済みなら更新する・存在しなければ新しく作成する
     if (gantt) {
-      gantt.refresh(tasks);
+      gantt.refresh(tasks, {...options, select_day: props.selectDay});
     } else {
-      const ganttInstance = new Gantt(ganttRef.current, tasks, options);
+      const ganttInstance = new Gantt(ganttRef.current, tasks, {
+        ...options,
+        select_day: props.selectDay,
+      });
 
       // Ganttインスタンスを保持する
       setGantt(ganttInstance);
     }
-  }, [props.tasks, props.options, gantt]);
+  }, [props.tasks, props.options, gantt, props.selectDay]);
 
   return (
     <div className="gc__frappe-gantt-react">

--- a/src/components/Gantt/types.d.ts
+++ b/src/components/Gantt/types.d.ts
@@ -23,9 +23,9 @@ export type GanttProps = {
     headerLowerTextY?: number;
     headerUpperTextY?: number;
     headerDayOfWeekTextY?: number;
-    bodyPosition?: 0;
-    startBeforeDay?: 30;
-    endLaterDay?: 30;
+    bodyPosition?: number;
+    startBeforeDay?: number;
+    endLaterDay?: number;
   };
 };
 
@@ -37,4 +37,5 @@ type Task = {
   progress?: number;
   dependencies?: string;
   customClass?: string;
+  customRowClass?: string;
 };

--- a/src/components/Gantt/types.d.ts
+++ b/src/components/Gantt/types.d.ts
@@ -1,5 +1,6 @@
 export type GanttProps = {
   tasks: Array<Array<Task>>;
+  selectDay?: string;
   options?: {
     onClick?: (task: Task) => any;
     onDateChange?: (task: Task, start: Date, end: Date) => any;
@@ -22,6 +23,9 @@ export type GanttProps = {
     headerLowerTextY?: number;
     headerUpperTextY?: number;
     headerDayOfWeekTextY?: number;
+    bodyPosition?: 0;
+    startBeforeDay?: 30;
+    endLaterDay?: 30;
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1202,10 +1202,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
-"@gemcook/gantt@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@gemcook/gantt/-/gantt-0.1.2.tgz#7cc3f12a9bdbbfdbebfbe0d65d33bef48627d68c"
-  integrity sha512-YfEGD5lPBhBjguiSFM6ILoxevkBacJcb45+DqbwPh4shdkJaKlMrOOlUh7B4EFp5HDW1oWFMghZRMDyJkV/Z5g==
+"@gemcook/gantt@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@gemcook/gantt/-/gantt-0.1.4.tgz#4f531d603933bfd416cc4441128f0161fb7dfd37"
+  integrity sha512-gZ8c0vWIaJZc1eKl7D2uMCN8oLpV5vdgSqXWJlG/WQbRIshU4xZwC0KA7IgoClCZm+XaZID46hGh/o9KfEpsow==
 
 "@gemcook/utils@^5.1.7":
   version "5.1.7"


### PR DESCRIPTION
### 動作確認方法

1. `yarn` を実行する
2. `make start` を実行する

### アサイニーが確認した項目

1. 日付を渡すとその日付のガントを表示できることを確認
2. 渡した日付の30日前がガントの始まりになっていることを確認
    - パラメータを渡すことで変更できることを確認
3. 渡した日付の60日後がガントの終わりになっていることを確認
    - パラメータを渡すことで変更できることを確認 

### 技術的変更点

- インストールしたgemcook/ganttのバージョンアップ
- gemcook/ganttに空配列を渡してもエラーが出ないように修正したため、処理を中断する記述の削除
- gemcook/ganttに選択した日付を渡せるように修正

### レビュアーに対する注意点

gemcook/ganttのバージョンを上げたことによる機能の追加をしています。
src/GanttSample.tsx では動作確認用の変更を行っています。
gemcook/ganttに空配列を渡してもエラーが出ないように修正したため、対応する処理を削除しました。

### 課題とは直接関係がないが修正した項目

- customRowClassとbodyPositionのパラメータを受け取れるように、型を追加

### 今回保留した項目

なし

### リリース・マージに対する注意点

なし

### その他

なし