### PR TITLE
gemcook/gantt-reactでガントバーをクリックした時、渡した関数を実行できるように修正する。

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@gemcook/gantt": "^0.1.6",
+    "@gemcook/gantt": "^0.1.7",
     "@gemcook/utils": "^5.2.0",
     "@types/jest": "^24.0.15",
     "@types/node": "12.0.10",

--- a/src/GanttSample.tsx
+++ b/src/GanttSample.tsx
@@ -57,9 +57,6 @@ const GanttDemo: React.FC = () => {
   ];
 
   const options = {
-    onDateChange: (task: any) => {
-      console.log(task);
-    },
     headerHeight: 50,
     barHeight: 30,
     viewMode: 'Day',

--- a/src/components/Gantt/index.tsx
+++ b/src/components/Gantt/index.tsx
@@ -17,17 +17,36 @@ const ReactGantt: React.FC<GanttProps> = props => {
 
     // もしガントが表示済みなら更新する・存在しなければ新しく作成する
     if (gantt) {
-      gantt.refresh(tasks, {...options, select_day: props.selectDay});
+      // TODO オプションをオブジェクトで受け取らないように修正する
+      // NOTE ganttを再生成する関数
+      gantt.refresh(tasks, {
+        ...options,
+        select_day: props.selectDay,
+        on_click: props.onClick,
+        on_date_change: props.onDateChange,
+        on_progress_change: props.onProgressChange,
+        on_view_change: props.onViewChange,
+        on_contextmenu: props.onContextMenu,
+        on_gantt_contextmenu: props.onGanttContextMenu,
+      });
     } else {
+      // TODO オプションをオブジェクトで受け取らないように修正する
+      // NOTE 新しいガントを作成する
       const ganttInstance = new Gantt(ganttRef.current, tasks, {
         ...options,
         select_day: props.selectDay,
+        on_click: props.onClick,
+        on_date_change: props.onDateChange,
+        on_progress_change: props.onProgressChange,
+        on_view_change: props.onViewChange,
+        on_contextmenu: props.onContextMenu,
+        on_gantt_contextmenu: props.onGanttContextMenu,
       });
 
       // Ganttインスタンスを保持する
       setGantt(ganttInstance);
     }
-  }, [props.tasks, props.options, gantt, props.selectDay]);
+  }, [props, gantt]);
 
   return (
     <div className="gc__frappe-gantt-react">

--- a/src/components/Gantt/index.tsx
+++ b/src/components/Gantt/index.tsx
@@ -51,7 +51,7 @@ const ReactGantt: React.FC<GanttProps> = props => {
       // NOTE ganttを再生成する関数
       gantt.refresh(tasks);
     }
-  }, [props.tasks, gantt, props.options, props.selectDay]);
+  }, [props.tasks, props.options, gantt, props.selectDay]);
 
   return (
     <div className="gc__frappe-gantt-react">

--- a/src/components/Gantt/index.tsx
+++ b/src/components/Gantt/index.tsx
@@ -42,11 +42,14 @@ const ReactGantt: React.FC<GanttProps> = props => {
 
     // もしガントが表示済みなら更新する
     if (gantt) {
-      // NOTE ganttを再生成する関数
-      gantt.refresh(tasks, {
+      // ガントのオプションを更新する
+      Object.assign(gantt.options, {
         ...options,
         select_day: props.selectDay,
       });
+
+      // NOTE ganttを再生成する関数
+      gantt.refresh(tasks);
     }
   }, [props.tasks, gantt, props.options, props.selectDay]);
 

--- a/src/components/Gantt/index.tsx
+++ b/src/components/Gantt/index.tsx
@@ -21,7 +21,7 @@ const ReactGantt: React.FC<GanttProps> = props => {
       const ganttInstance = new Gantt(ganttRef.current, tasks, {
         ...options,
         select_day: props.selectDay,
-        on_click: props.onClick,
+        on_click: props.onGanttBarClick,
         on_date_change: props.onDateChange,
         on_progress_change: props.onProgressChange,
         on_view_change: props.onViewChange,

--- a/src/components/Gantt/index.tsx
+++ b/src/components/Gantt/index.tsx
@@ -10,27 +10,13 @@ const ReactGantt: React.FC<GanttProps> = props => {
   const ganttRef = useRef(null);
   const [gantt, setGantt] = useState();
 
+  // TODO hooksファイルを作成し、社内の最新の構成に合わせる
   useEffect(() => {
-    // キャメルケースで受け取った値をスネークケースにする。
-    const options = collection.toSnakeKeys(props.options);
-    const tasks = collection.toSnakeKeys(props.tasks);
+    if (!gantt) {
+      // キャメルケースで受け取った値をスネークケースにする。
+      const options = collection.toSnakeKeys(props.options);
+      const tasks = collection.toSnakeKeys(props.tasks);
 
-    // もしガントが表示済みなら更新する・存在しなければ新しく作成する
-    if (gantt) {
-      // TODO オプションをオブジェクトで受け取らないように修正する
-      // NOTE ganttを再生成する関数
-      gantt.refresh(tasks, {
-        ...options,
-        select_day: props.selectDay,
-        on_click: props.onClick,
-        on_date_change: props.onDateChange,
-        on_progress_change: props.onProgressChange,
-        on_view_change: props.onViewChange,
-        on_contextmenu: props.onContextMenu,
-        on_gantt_contextmenu: props.onGanttContextMenu,
-      });
-    } else {
-      // TODO オプションをオブジェクトで受け取らないように修正する
       // NOTE 新しいガントを作成する
       const ganttInstance = new Gantt(ganttRef.current, tasks, {
         ...options,
@@ -46,7 +32,23 @@ const ReactGantt: React.FC<GanttProps> = props => {
       // Ganttインスタンスを保持する
       setGantt(ganttInstance);
     }
-  }, [props, gantt]);
+  }, [gantt, props]);
+
+  // TODO hooksファイルを作成し、社内の最新の構成に合わせる
+  useEffect(() => {
+    // キャメルケースで受け取った値をスネークケースにする。
+    const options = collection.toSnakeKeys(props.options);
+    const tasks = collection.toSnakeKeys(props.tasks);
+
+    // もしガントが表示済みなら更新する
+    if (gantt) {
+      // NOTE ganttを再生成する関数
+      gantt.refresh(tasks, {
+        ...options,
+        select_day: props.selectDay,
+      });
+    }
+  }, [props.tasks, gantt, props.options, props.selectDay]);
 
   return (
     <div className="gc__frappe-gantt-react">

--- a/src/components/Gantt/types.d.ts
+++ b/src/components/Gantt/types.d.ts
@@ -1,11 +1,13 @@
 export type GanttProps = {
   tasks: Array<Array<Task>>;
   selectDay?: string;
+  onClick?: (task: Task) => void;
+  onDateChange?: (task: Task, start: Date, end: Date) => void;
+  onProgressChange?: (task: Task, progress: number) => void;
+  onViewChange?: (viewMode: string) => void;
+  onContextMenu?: (e: Event, task: Task) => void;
+  onGanttContextMenu?: (e: Event, new_task: Task, tasks: Array<task>) => void;
   options?: {
-    onClick?: (task: Task) => any;
-    onDateChange?: (task: Task, start: Date, end: Date) => any;
-    onProgressChange?: (task: Task, progress: number) => any;
-    onViewChange?: (viewMode: string) => any;
     headerHeight?: number;
     coumnWidth?: number;
     step?: number;

--- a/src/components/Gantt/types.d.ts
+++ b/src/components/Gantt/types.d.ts
@@ -5,8 +5,12 @@ export type GanttProps = {
   onDateChange?: (task: Task, start: Date, end: Date) => void;
   onProgressChange?: (task: Task, progress: number) => void;
   onViewChange?: (viewMode: string) => void;
-  onContextMenu?: (e: Event, task: Task) => void;
-  onGanttContextMenu?: (e: Event, new_task: Task, tasks: Array<task>) => void;
+  onContextMenu?: (e: MouseEvent, task: Task) => void;
+  onGanttContextMenu?: (
+    e: MouseEvent,
+    new_task: Task,
+    tasks: Array<Task>
+  ) => void;
   options?: {
     headerHeight?: number;
     coumnWidth?: number;

--- a/src/components/Gantt/types.d.ts
+++ b/src/components/Gantt/types.d.ts
@@ -1,7 +1,7 @@
 export type GanttProps = {
   tasks: Array<Array<Task>>;
   selectDay?: string;
-  onClick?: (task: Task) => void;
+  onGanttBarClick?: (task: Task) => void;
   onDateChange?: (task: Task, start: Date, end: Date) => void;
   onProgressChange?: (task: Task, progress: number) => void;
   onViewChange?: (viewMode: string) => void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1202,10 +1202,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
-"@gemcook/gantt@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@gemcook/gantt/-/gantt-0.1.6.tgz#753171cd6a5c1abd45a5bf0bf5eca06039c09316"
-  integrity sha512-/99AiAbiHSzqfdsl4G1tCgtFrL6Okh64XXOstLy7C4lzQNwPeD7aBBY+pHmsB2bBwAqK9w6KemjmR3eBVmUHaw==
+"@gemcook/gantt@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@gemcook/gantt/-/gantt-0.1.7.tgz#2214fa062c59ba92c104c9a2654b5f04800c6a27"
+  integrity sha512-KF6CrLoc+nJ/6koUtRY4XBoYX+sajKXyOar/XFFjPbP01JIJp7ylefyNzS9nabKZtOqzEnuIg1Nn3Q7Jdb8Q3Q==
 
 "@gemcook/utils@^5.2.0":
   version "5.2.0"


### PR DESCRIPTION
### 動作確認方法

1.`make start` を実行

### アサイニーが確認した項目

- ガントバーをクリックした時、関数を実行できることを確認
- ガントの背景をクリックした時、新しいガントバーが生成されることを確認

### 技術的変更点

- `gemcook/gantt` のバージョンアップ
- `onClick` 等の関数を受け取り、実行できるように修正

### レビュアーに対する注意点

`hooks.ts` ファイルが作成されていませんが、課題が立っているため、そちらで社内の構成に合わせる修正対応を行います。

### 課題とは直接関係がないが修正した項目

- `gemcook/gantt` のバージョンアップ
- 動作確認用ファイルの `console.log` の削除
- 一部の型を修正

### 今回保留した項目

なし

### リリース・マージに対する注意点

なし

### その他

なし
