### PR TITLE
gemcook/gantt-reactでガントバーのみを更新できるようにする。

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@gemcook/gantt": "^0.1.9-test",
+    "@gemcook/gantt": "^0.1.9",
     "@gemcook/utils": "^5.2.0",
     "@types/jest": "^24.0.15",
     "@types/node": "12.0.10",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@gemcook/gantt": "^0.1.8",
+    "@gemcook/gantt": "^0.1.9-test",
     "@gemcook/utils": "^5.2.0",
     "@types/jest": "^24.0.15",
     "@types/node": "12.0.10",

--- a/src/components/Gantt/index.tsx
+++ b/src/components/Gantt/index.tsx
@@ -44,7 +44,7 @@ const ReactGantt: React.FC<GanttProps> = props => {
       return;
     }
 
-    // ガントの選択された日付と、配列の長さが変わっていなければ更新
+    // ガントの選択された日付と、配列の長さが変わっていなければガントバーのみを更新
     if (
       gantt.tasks.length === tasks.length &&
       gantt.options.select_day === props.selectDay

--- a/src/components/Gantt/index.tsx
+++ b/src/components/Gantt/index.tsx
@@ -44,7 +44,7 @@ const ReactGantt: React.FC<GanttProps> = props => {
       return;
     }
 
-    // ガントの選択された日付と、配列の長さが変わっていなければガントバーのみを更新
+    // 選択された日付・配列の長さが変わっていなければガントバーのみを更新
     if (
       gantt.tasks.length === tasks.length &&
       gantt.options.select_day === props.selectDay

--- a/src/components/Gantt/index.tsx
+++ b/src/components/Gantt/index.tsx
@@ -40,17 +40,28 @@ const ReactGantt: React.FC<GanttProps> = props => {
     const options = collection.toSnakeKeys(props.options);
     const tasks = collection.toSnakeKeys(props.tasks);
 
-    // もしガントが表示済みなら更新する
-    if (gantt) {
-      // ガントのオプションを更新する
-      Object.assign(gantt.options, {
-        ...options,
-        select_day: props.selectDay,
-      });
-
-      // NOTE ganttを再生成する関数
-      gantt.refresh(tasks);
+    if (!gantt) {
+      return;
     }
+
+    // ガントの選択された日付と、配列の長さが変わっていなければ更新
+    if (
+      gantt.tasks.length === tasks.length &&
+      gantt.options.select_day === props.selectDay
+    ) {
+      // gemcook/ganttの関数
+      gantt.refresh_tasks(tasks);
+      return;
+    }
+
+    // ガントのオプションを更新する
+    Object.assign(gantt.options, {
+      ...options,
+      select_day: props.selectDay,
+    });
+
+    // NOTE ganttを再生成する関数
+    gantt.refresh(tasks);
   }, [props.tasks, props.options, gantt, props.selectDay]);
 
   // TODO hooksファイルを作成し、社内の最新の構成に合わせる

--- a/yarn.lock
+++ b/yarn.lock
@@ -1202,10 +1202,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
-"@gemcook/gantt@^0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@gemcook/gantt/-/gantt-0.1.8.tgz#e27e48e331f0779ba1054284a361b59df60689f7"
-  integrity sha512-QeeQCX+EAKL4XqUehdOCqzwh05HqjyM/fMpDovJEZ67dBAeDqljobdcepcJ8fYrqc6cqu9OmFAcAZfs9DkTbaw==
+"@gemcook/gantt@^0.1.9-test":
+  version "0.1.9-test"
+  resolved "https://registry.yarnpkg.com/@gemcook/gantt/-/gantt-0.1.9-test.tgz#bf60fcbb09afdcd342d9af4522b9cefbef978181"
+  integrity sha512-q7dVJAqbCJV4H2LUK499jVjZ52hC0Y/ZQuGt9+V66KWNwkuX2sDf7NQgi2BMkI/paDDTy0FbMdrlfN+QEYI7MA==
 
 "@gemcook/utils@^5.2.0":
   version "5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1202,10 +1202,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
-"@gemcook/gantt@^0.1.9-test":
-  version "0.1.9-test"
-  resolved "https://registry.yarnpkg.com/@gemcook/gantt/-/gantt-0.1.9-test.tgz#bf60fcbb09afdcd342d9af4522b9cefbef978181"
-  integrity sha512-q7dVJAqbCJV4H2LUK499jVjZ52hC0Y/ZQuGt9+V66KWNwkuX2sDf7NQgi2BMkI/paDDTy0FbMdrlfN+QEYI7MA==
+"@gemcook/gantt@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@gemcook/gantt/-/gantt-0.1.9.tgz#2d57af3dce629e820ef406af640dbcc4c1f490d4"
+  integrity sha512-IVX1Z7aZnF8oYFmClTCr4Nep8ATOML1EoYCa1Jl9uLU+DUs8iFIK/A8QjHitT5JedAyudspciV9pRUwfBR4ewg==
 
 "@gemcook/utils@^5.2.0":
   version "5.2.0"


### PR DESCRIPTION
### 動作確認方法

1. `make start` を実行

### アサイニーが確認した項目

- ガントバーのみを更新できることを確認

### 技術的変更点

- gemcook/ganttのバージョンアップ
- gemcook/ganttの関数を実行し、ガントバーのみを更新できる機能を追加

### レビュアーに対する注意点

- 一部 `_` 繋がり（スネークケース）で記述している箇所がありますが、gemcook/ganttの関数の実行行っているためです。この箇所をキャメルケースにしようとすると正しく値が渡せず動かないため、スネークケースで記述しています。

### 課題とは直接関係がないが修正した項目

なし

### 今回保留した項目

なし

### リリース・マージに対する注意点

なし

### その他

なし
