### PR TITLE
gemcook/gantt-reactでインストールするgemcook/ganttのバージョンを上げる。

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@gemcook/gantt": "^0.1.9",
+    "@gemcook/gantt": "^0.2.0",
     "@gemcook/utils": "^5.2.0",
     "@types/jest": "^24.0.15",
     "@types/node": "12.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1202,10 +1202,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
-"@gemcook/gantt@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@gemcook/gantt/-/gantt-0.1.9.tgz#2d57af3dce629e820ef406af640dbcc4c1f490d4"
-  integrity sha512-IVX1Z7aZnF8oYFmClTCr4Nep8ATOML1EoYCa1Jl9uLU+DUs8iFIK/A8QjHitT5JedAyudspciV9pRUwfBR4ewg==
+"@gemcook/gantt@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@gemcook/gantt/-/gantt-0.2.0.tgz#048d986b8b5268c24d803ebeb1e7ad9287f7c8c6"
+  integrity sha512-mP4hT8hQqqVm4aPBZ1c/ylNB2xxkoPnQ146nsHma2i8PmbgYxY2ki+WhvDsiMYztwKFzPoL6XUqlr566XK2frQ==
 
 "@gemcook/utils@^5.2.0":
   version "5.2.0"


### PR DESCRIPTION
### 動作確認方法

1. `make start` を実行
2. ガントの背景をクリックし、新規ガントバーを作成

### アサイニーが確認した項目

- デベロッパーツールで新規ガントバーが `all-bar` に含まれていることを確認

### 技術的変更点

- gemcook/ganttのバージョンの変更

### レビュアーに対する注意点

ライブラリのバージョンアップのみを行ったため、ライブラリの変更点が反映されているかを確認しています。

### 課題とは直接関係がないが修正した項目

なし

### 今回保留した項目

なし

### リリース・マージに対する注意点

なし

### その他

なし