### PR TITLE
GC_FR-83 [gemcook/gantt-react]index.scssをexportするようにbuild設定を修正する。

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gemcook/gantt-react",
-  "version": "0.5.7-test",
+  "version": "0.1.7",
   "author": "Gemcook Engineers <engineers@gemcook.com>",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gemcook/gantt-react",
-  "version": "0.1.7",
+  "version": "0.5.7-test",
   "author": "Gemcook Engineers <engineers@gemcook.com>",
   "license": "MIT",
   "main": "lib/index.js",
@@ -51,6 +51,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-react-hooks": "^1.6.0",
+    "fs-extra": "^8.1.0",
     "jest": "24.7.1",
     "node-sass": "^4.12.0",
     "prettier": "^1.18.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+const fs = require('fs-extra');
 const resolve = require('rollup-plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');
 const babel = require('rollup-plugin-babel');
@@ -53,6 +54,18 @@ export default [
         extensions: ['.css', '.scss'],
         extract: 'lib/styles/index.css',
       }),
+      {
+        name: 'sync scss',
+        buildEnd: err => {
+          if (err) {
+            throw err;
+          }
+
+          fs.copySync('./src/styles', './lib/styles', {
+            dereference: true,
+          });
+        },
+      },
     ],
     output: {
       file: 'lib/index.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4893,6 +4893,15 @@ fs-extra@^4.0.2:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -5129,6 +5138,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+
+graceful-fs@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
+  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
### 動作確認方法

1. `make build` を実行し、ビルドされたファイルに `index.scss` が存在することを確認する

### アサイニーが確認した項目

- `make build` を実行し、`lib/styles/` 以下に `index.scss` が存在することを確認 
- npmにtestタグでpublishを実行し、`index.scss` がエクスポートされていることを確認

### 技術的変更点

- `devDependencies` に `fs-extra` の追加
- `rollup.config.js` で `rollup` のビルド終了時に `src/styles` をコピーする処理の追加

### レビュアーに対する注意点

gemcookの他ライブラリを参考にindex.scssをエクスポートする処理を追加しています。

### 課題とは直接関係がないが修正した項目

なし

### 今回保留した項目

- githubが出している `Security Alerts` の保留

### リリース・マージに対する注意点

なし

### その他

なし
